### PR TITLE
fix showAddress error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-foundation/ledgerjs-hw-app-cardano",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "files": [
     "lib"
   ],

--- a/src/Ada.js
+++ b/src/Ada.js
@@ -171,7 +171,8 @@ export default class Ada {
       "getVersion",
       "getExtendedPublicKey",
       "signTransaction",
-      "deriveAddress"
+      "deriveAddress",
+      "showAddress"
     ];
     this.transport.decorateAppAPIMethods(this, this.methods, scrambleKey);
     this.send = wrapConvertError(this.transport.send);


### PR DESCRIPTION
Without this, calling `showAddress` from Yoroi gives

```
TypeError: Cannot read property 'length' of undefined
    at wrapApdu (TransportU2F.js?95a8:61)
    at attemptExchange (TransportU2F.js?95a8:77)
    at TransportU2F._callee2$ (TransportU2F.js?95a8:183)
    at tryCatch (runtime.js?4a57:62)
    at Generator.invoke [as _invoke] (runtime.js?4a57:296)
    at Generator.prototype.(anonymous function) [as next] (webpack-internal:///./node_modules/regenerator-runtime/runtime.js:114:21)
    at step (asyncToGenerator.js?7b11:17)
    at eval (asyncToGenerator.js?7b11:35)
    at new Promise (<anonymous>)
    at new F (_export.js?90cd:35)
```

After looking it up, it looks like this is caused by forgetting a public function inside decorateAppAPIMethods. You can see somebody fixing the same bug the same way [here](https://github.com/LedgerHQ/ledgerjs/pull/163/commits/f2fa4ca5d05b798674641cc648b358c9f0a3d82f). This is consistent with my own investigation