### PR TITLE
Hw transport dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-foundation/ledgerjs-hw-app-cardano",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   "author": "VacuumLabs <adalite@vacuumlabs.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/hw-transport": "^4.35.0",
     "babel-polyfill": "^6.26.0",
     "babel-runtime": "^6.26.0",
     "base-x": "^3.0.5",
     "node-int64": "^0.4.0"
   },
   "devDependencies": {
+    "@ledgerhq/hw-transport": "^4.35.0",
     "@ledgerhq/hw-transport-node-hid": "^4.35.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/src/Ada.js
+++ b/src/Ada.js
@@ -1,6 +1,7 @@
 /********************************************************************************
  *   Ledger Node JS API
  *   (c) 2016-2017 Ledger
+ *   (c) 2019 VacuumLabs
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/Ada.js
+++ b/src/Ada.js
@@ -16,9 +16,6 @@
  ********************************************************************************/
 // @flow
 
-import type Transport from "@ledgerhq/hw-transport";
-import { TransportStatusError } from "@ledgerhq/hw-transport";
-
 import utils, { Precondition, Assert } from "./utils";
 
 const CLA = 0xd7;
@@ -160,12 +157,28 @@ const wrapConvertError = fn => async (...args) => {
 
 type SendFn = (number, number, number, number, Buffer) => Promise<Buffer>;
 
+//
+type TransportBase = {
+  send: (
+    cla: number,
+    ins: number,
+    p1: number,
+    p2: number,
+    data: Buffer
+  ) => Promise<Buffer>,
+  decorateAppAPIMethods: (
+    instance: any,
+    methods: Array<string>,
+    scrambleKey: string
+  ) => void
+};
+
 export default class Ada {
-  transport: Transport<*>;
+  transport: TransportBase;
   methods: Array<string>;
   send: SendFn;
 
-  constructor(transport: Transport<*>, scrambleKey: string = "ADA") {
+  constructor(transport: TransportBase, scrambleKey: string = "ADA") {
     this.transport = transport;
     this.methods = [
       "getVersion",


### PR DESCRIPTION
- Removes dependency on @ledgerhq/hw-transport
- As a part of the change use custom type for Transport (only what we need from it)