### PR TITLE
Release 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-foundation/ledgerjs-hw-app-cardano",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "files": [
     "lib"
   ],

--- a/src/Ada.js
+++ b/src/Ada.js
@@ -59,13 +59,13 @@ export type AssetGroup =
 
 export type TxOutputTypeAddress = {|
   amountStr: string,
-  tokenBundle: Array<AssetGroup>,
+  tokenBundle: ?Array<AssetGroup>,
   addressHex: string
 |};
 
 export type TxOutputTypeAddressParams = {|
   amountStr: string,
-  tokenBundle: Array<AssetGroup>,
+  tokenBundle: ?Array<AssetGroup>,
   addressTypeNibble: $Values<typeof AddressTypeNibbles>,
   spendingPath: BIP32Path,
   stakingPath: ?BIP32Path,
@@ -599,7 +599,7 @@ export default class Ada {
     if (!appHasMultiassetSupport) {
 
       const containsMultiassets = outputs.some(
-        output => (output.tokenBundle != null)
+        output => (output.tokenBundle && output.tokenBundle.length > 0)
       );
 
       // for older app versions:
@@ -748,7 +748,7 @@ export default class Ada {
         0
       );
 
-      if (output.tokenBundle != null) {
+      if (output.tokenBundle && output.tokenBundle.length > 0) {
         for (const assetGroup of output.tokenBundle) {
           const data = Buffer.concat([
             utils.hex_to_buf(assetGroup.policyIdHex),

--- a/src/cardano.js
+++ b/src/cardano.js
@@ -220,7 +220,7 @@ export function validateTransaction(
       Precondition.check(!isSigningPoolRegistrationAsOwner, TxErrors.OUTPUT_WITH_PATH);
     }
 
-    if (output.tokenBundle) {
+    if (output.tokenBundle != null) {
       Precondition.checkIsArray(output.tokenBundle, TxErrors.OUTPUT_INVALID_TOKEN_BUNDLE);
       Precondition.check(output.tokenBundle.length <= ASSET_GROUPS_MAX);
 


### PR DESCRIPTION
Motivation: signTransaction command was failing with ledger app older than 2.2.0 in case tokenBundle (a property introduced in ledger app 2.2.0) was an empty array which is otherwise valid because that means the output indeed doesn't have any.

Changes:

* relax the tokenBundle feature check to allow an empty array
* update flow types to make tokenBundle optional which was inconsistent with the original logic that internally dealt with null but the type itself required presence of the tokenBundle array

Testing:

* yarn test-integration --grep signTx passes both for ledger cardano app 2.1.0 (tests that apply) and 2.2.0
* tried passing tokenBundle set to an empty array but did not include in the commit to not introduce unnecessary conflicts with the ongoing refactor